### PR TITLE
docs(setup): fix syntax highlighting

### DIFF
--- a/docs/content/en/setup.md
+++ b/docs/content/en/setup.md
@@ -33,7 +33,7 @@ Add `@nuxt/image` dependency to your project:
 
 Next, you need to register module inside `nuxt.config`:
 
-```bash{}[.nuxt.config.js]
+```js{}[nuxt.config.js]
 export default {
   modules: [
     '@nuxt/image'


### PR DESCRIPTION
**bash** `.nuxt.config.js` → **js** `nuxt.config.js`