### PR TITLE
docs: fix code indentation

### DIFF
--- a/docs/content/en/examples/random-provider.md
+++ b/docs/content/en/examples/random-provider.md
@@ -11,8 +11,8 @@ category: Examples
   ```js{}[~/providers/random/index.js]
   export default function(providerOptions) {
     return {
-        runtime: require.resolve('./runtime'),
-        runtimeOptions: providerOptions
+      runtime: require.resolve('./runtime'),
+      runtimeOptions: providerOptions
     }
   }
   ```

--- a/docs/content/en/nuxt-image.md
+++ b/docs/content/en/nuxt-image.md
@@ -11,7 +11,7 @@ Path to image file. `src` sould be in form of absolute path and starts with `/`.
 
 ```vue
 <template>
-    <nuxt-image :src="src" ... />
+  <nuxt-image :src="src" ... />
 </template>
 ```
 


### PR DESCRIPTION
4 spaces → 2 spaces